### PR TITLE
docs: clarify encode parameter

### DIFF
--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -27,7 +27,7 @@ There are 2 endpoints available:
 | language        | `en` (default is auto recognition)             | Source language code (see supported languages)                 |
 | word_timestamps | false (default)                                | Enable word-level timestamps (Faster Whisper only)             |
 | vad_filter      | false (default)                                | Enable voice activity detection filtering (Faster Whisper only) |
-| encode          | true (default)                                 | Encode audio through FFmpeg before processing                  |
+| encode          | true (default)                                 | Encode audio through FFmpeg before processing. When `false`, the service expects mono 16-kHz PCM audio; other formats will fail unless you force FFmpeg processing. |
 | diarize         | false (default)                                | Enable speaker diarization (WhisperX only)                     |
 | min_speakers    | null (default)                                 | Minimum number of speakers for diarization (WhisperX only)     |
 | max_speakers    | null (default)                                 | Maximum number of speakers for diarization (WhisperX only)     |


### PR DESCRIPTION
## Summary
- clarify the audio requirements when `encode` is disabled

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c2d2e861c832d892126c42affacec