### PR TITLE
Fix WhisperX language detection

### DIFF
--- a/app/asr_models/mbain_whisperx_engine.py
+++ b/app/asr_models/mbain_whisperx_engine.py
@@ -99,8 +99,9 @@ class WhisperXASR(ASRModel):
                 self.load_model()
             _, probs = self.model['whisperx'].detect_language(mel)
         detected_lang_code = max(probs, key=probs.get)
+        detected_lang_confidence = probs[detected_lang_code]
 
-        return detected_lang_code
+        return detected_lang_code, detected_lang_confidence
 
     def write_result(self, result: dict, file: BinaryIO, output: Union[str, None]):
         default_options = {


### PR DESCRIPTION
## Summary
- return language confidence from WhisperX language detection
- keep `/detect-language` endpoint compatible with WhisperX

## Testing
- `poetry run ruff check app/asr_models/mbain_whisperx_engine.py`

------
https://chatgpt.com/codex/tasks/task_e_684c2d1fa7d4832da06b9796732d6fc7